### PR TITLE
Updated readme to reflect Ubuntu installation

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -8,4 +8,6 @@ With that in mind, simply run `watchntouch` in the directory you'd like to watch
 
 Installation on most platforms should be available via `pip install watchntouch`.
 
+Installation on Ubuntu may require `sudo apt-get install python-pip pythion-dev build-essential` `sudo pip2.7 install PyAML` `sudo pip2.7 install pathtools` `sudo pip2.7 install argh==0.8.1` and then `sudo pip2.7 install watchntouch`. watchntouch doesn't pick up the latest versions of argh hence the version specification for that package.
+
 Good luck!


### PR DESCRIPTION
Having recently attempted installation on Ubuntu 12.04, I found these additional installation requirements shown above - python build packages from apt-get, plus a few packages from pip - PyYAML, argh (newest versions don't work but 0.8.1 does) and possibly also pathtools.